### PR TITLE
Add more surprising arguments benchmarks

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
 
     <button id="runNormalButton">Run normal</button> <span id="normalResult"></span><br />
     <button id="runArgumentsButton">Run arguments</button> <span id="argumentsResult"></span><br />
+    <button id="runIndexedArgumentsButton">Run indexed arguments</button> <span id="indexedArgumentsResult"></span><br />
+    <button id="runFastArgLengthButton">Run fast arguments length check</button> <span id="fastArgLengthResult"></span><br />
+    <button id="runSlowArgLengthButton">Run slow arguments length check</button> <span id="slowArgLengthResult"></span><br />
     <button id="runSpreadOpButton">Run sperad operator</button> <span id="spreadOpResult"></span><br />
 
     <h2>How to test</h2>
@@ -40,6 +43,36 @@
         document.getElementById('argumentsResult').innerText = (endTime - startTime).toFixed(2) + 'ms';
       });
 
+      document.getElementById('runIndexedArgumentsButton').addEventListener('click', () => {
+        const startTime = performance.now();
+        let sum = 0;
+        for (let i = 0; i < loopNum; i++) {
+          sum += indexedArguments(1, 2);
+        }
+        const endTime = performance.now();
+        document.getElementById('indexedArgumentsResult').innerText = (endTime - startTime).toFixed(2) + 'ms';
+      });
+
+      document.getElementById('runFastArgLengthButton').addEventListener('click', () => {
+        const startTime = performance.now();
+        let sum = 0;
+        for (let i = 0; i < loopNum; i++) {
+          sum += fastArgLength(1, 2);
+        }
+        const endTime = performance.now();
+        document.getElementById('fastArgLengthResult').innerText = (endTime - startTime).toFixed(2) + 'ms';
+      });
+
+      document.getElementById('runSlowArgLengthButton').addEventListener('click', () => {
+        const startTime = performance.now();
+        let sum = 0;
+        for (let i = 0; i < loopNum; i++) {
+          sum += slowArgLength(1, 2);
+        }
+        const endTime = performance.now();
+        document.getElementById('slowArgLengthResult').innerText = (endTime - startTime).toFixed(2) + 'ms';
+      });
+
       document.getElementById('runSpreadOpButton').addEventListener('click', () => {
         const startTime = performance.now();
         let sum = 0;
@@ -60,6 +93,22 @@
 
       function leakyArguments() {
         return other.apply(this, arguments);
+      }
+
+      function indexedArguments() {
+        return other(arguments[0], arguments[1]);
+      }
+
+      function fastArgLength(a, b) {
+        if (arguments.length > 0) {
+          return other(a, b);
+        }
+      }
+
+      function slowArgLength(a, b) {
+        if (arguments.length > 2) {
+          return other(a, b);
+        }
       }
 
       const spreadOp = (...args) => {


### PR DESCRIPTION
Added more tests to demonstrate some surprising behavior in firefox.

- indexedArguments: Demonstrates that a performance impact occurs even if you don't pass the entire arguments array to a function, but also if you simply index the values out of the array and call the `other` function in a normal manner.
- fastArgLength: Demonstrats that there is no performance impact if you check arguments.length, as long as the condition evaluates to true.
- slowArgLength: Demonstrats that there is a significant performance impact if you check arguments.length, and the condition evaluates to false.

You can test these additions here: https://raw.githack.com/brianpeiris/js-arguments-test/main/index.html